### PR TITLE
Add ability to copy diagrams as PNG images

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Install [Graphviz](http://www.graphviz.org/) to be able to generate all diagram 
 * Very fast live updates utilizing the power of PlantUML's SVG output and Atoms HTML views.
 * Fluent controls for panning and zooming PlantUML diagrams, including touch support.
 * Save UML diagrams as PNG, SVG or EPS.
+* Copy UML diagrams as PNG images.
 * Supports relative include paths in source files.
 
 # Settings

--- a/lib/plantuml-viewer-view.js
+++ b/lib/plantuml-viewer-view.js
@@ -9,6 +9,8 @@ var inherits = require('./cs-inherits')
 var path = require('path')
 var fs = require('fs')
 var svgPanZoom = require('svg-pan-zoom/src/svg-pan-zoom')
+var nativeImage = require('native-image')
+var clipboard = require('clipboard')
 
 PlantumlViewerView.content = function () {
   PlantumlViewerView.div({
@@ -81,6 +83,10 @@ function PlantumlViewerView (editor) {
     atom.commands.add(self.element, 'core:save', function (event) {
       event.stopPropagation()
       saveAs()
+    })
+    atom.commands.add(self.element, 'core:copy', function (event) {
+      event.stopPropagation()
+      copy()
     })
   }
 
@@ -176,5 +182,25 @@ function PlantumlViewerView (editor) {
       var gen = plantuml.generate(editor.getText(), plantumlOptions)
       gen.out.pipe(fileStream)
     }
+  }
+
+  function copy () {
+    var options = {
+      format: 'png',
+      include: includePath,
+      dot: atom.config.get('plantuml-viewer.graphvizDotExecutable'),
+      config: atom.config.get('plantuml-viewer.configFile'),
+      charset: atom.config.get('plantuml-viewer.charset')
+    }
+
+    var gen = plantuml.generate(editor.getText(), options)
+
+    var chunks = []
+    gen.out.on('data', function (chunk) { chunks.push(chunk) })
+    gen.out.on('end', function () {
+      var buffer = Buffer.concat(chunks)
+      var image = nativeImage.createFromBuffer(buffer)
+      clipboard.writeImage(image)
+    })
   }
 }

--- a/menus/plantuml-viewer.json
+++ b/menus/plantuml-viewer.json
@@ -1,7 +1,8 @@
 {
   "context-menu": {
     ".plantuml-viewer": [
-      { "label": "Save As\u2026", "command": "core:save-as" }
+      { "label": "Save As\u2026", "command": "core:save-as" },
+      { "label": "Copy", "command": "core:copy" }
     ],
     "atom-text-editor": [
       {


### PR DESCRIPTION
This pull request depends on atom being upgraded to newer Electron version: https://github.com/atom/atom/pull/7877