### PR TITLE
throttle image updates

### DIFF
--- a/lib/plantuml-viewer-view.js
+++ b/lib/plantuml-viewer-view.js
@@ -55,11 +55,11 @@ function PlantumlViewerView (editor) {
 
   var updateImageTimerId = 0
   function queueUpdate () {
-      if (updateImageTimerId) return
-      updateImageTimerId = setTimeout(function () {
-          updateImage()
-          updateImageTimerId = 0;
-      }, 20)
+    if (updateImageTimerId) return
+    updateImageTimerId = setTimeout(function () {
+      updateImage()
+      updateImageTimerId = 0
+    }, 20)
   }
 
   function attached () {

--- a/lib/plantuml-viewer-view.js
+++ b/lib/plantuml-viewer-view.js
@@ -53,22 +53,31 @@ function PlantumlViewerView (editor) {
     }, 0)
   })
 
+  var updateImageTimerId = 0
+  function queueUpdate () {
+      if (updateImageTimerId) return
+      updateImageTimerId = setTimeout(function () {
+          updateImage()
+          updateImageTimerId = 0;
+      }, 20)
+  }
+
   function attached () {
     disposables = new CompositeDisposable()
-    updateImage()
+    queueUpdate()
     if (atom.config.get('plantuml-viewer.liveUpdate')) {
       disposables.add(editor.getBuffer().onDidChange(function () {
         if (loading) {
           waitingToLoad = true
           return
         }
-        updateImage()
+        queueUpdate()
       }))
 
       interval = setInterval(function () {
         if (panZoom) {
           if (width !== self.width() || height !== self.height()) {
-            updateImage()
+            queueUpdate()
             width = self.width()
             height = self.height()
           }
@@ -151,7 +160,7 @@ function PlantumlViewerView (editor) {
 
       if (waitingToLoad) {
         waitingToLoad = false
-        updateImage()
+        queueUpdate()
       }
       loading = false
     })


### PR DESCRIPTION
This adds some really simple update throttling. This makes things less jumpy while typing.
Also, it fixes an issue where reloading the Atom window when the preview is open wouldn't work properly.
