### PR TITLE
Fixed all issues with not updating and blank panels

### DIFF
--- a/lib/config.json
+++ b/lib/config.json
@@ -3,6 +3,10 @@
     "type": "boolean",
     "default": true
   },
+  "useNailgun": {
+    "type": "boolean",
+    "default": false
+  },
   "openInSplitPane": {
     "type": "boolean",
     "default": true

--- a/lib/plantuml-viewer-editor.js
+++ b/lib/plantuml-viewer-editor.js
@@ -64,7 +64,7 @@ PlantumlViewerEditor.prototype.getText = function () {
 
 PlantumlViewerEditor.prototype.getBuffer = function () {
   if (this.editor) return this.editor.getBuffer()
-  return new Buffer()
+  return new Buffer(1)
 }
 
 PlantumlViewerEditor.prototype.isEqual = function (other) {

--- a/lib/plantuml-viewer-view.js
+++ b/lib/plantuml-viewer-view.js
@@ -43,20 +43,21 @@ function PlantumlViewerView (editor) {
     atom.workspace.paneForURI(editor.getURI()).activate()
   })
 
-  atom.workspace.onDidChangeActivePaneItem(function () {
-    // The DOM and visibility is not yet updated
-    var wasVisible = self.is(':visible')
-    if (wasVisible) return
-    // wait until update is complete
-    setTimeout(function () {
-      updatePanZoom()
-    }, 0)
-  })
-
   function attached () {
     disposables = new CompositeDisposable()
+
+    disposables.add(atom.workspace.onDidChangeActivePaneItem(function () {
+      // The DOM and visibility is not yet updated
+      var wasVisible = self.is(':visible')
+      if (wasVisible) return
+      // wait until update is complete
+      setTimeout(function () {
+        updatePanZoom()
+      }, 0)
+    }))
+
     updateImage()
-    if (atom.config.get('plantuml-viewer.liveUpdate')) {
+    if (atom.config.get('plantuml-viewer.liveUpdate') && editor.getBuffer()) {
       disposables.add(editor.getBuffer().onDidChange(function () {
         if (loading) {
           waitingToLoad = true

--- a/lib/plantuml-viewer.js
+++ b/lib/plantuml-viewer.js
@@ -15,7 +15,7 @@ function createPlantumlViewerEditor (uri, editorId) {
   if (!PlantumlViewerEditor) {
     PlantumlViewerEditor = require('./plantuml-viewer-editor')
   }
-  if (!nailgun) {
+  if (!nailgun && atom.config.get('plantuml-viewer.useNailgun')) {
     nailgun = plantuml.useNailgun()
   }
   return new PlantumlViewerEditor(uri, editorId)
@@ -65,30 +65,30 @@ function toggle () {
 
 function addViewerForUri (uri) {
   var prevActivePane = atom.workspace.getActivePane()
-  var options = { searchAllPanes: true }
+  var options = { searchAllPanes: true, activatePane: false }
 
   if (atom.config.get('plantuml-viewer.openInSplitPane')) {
     options.split = 'right'
   }
 
-  atom.workspace.open(uri, options).then(function (viewerView) {
-    prevActivePane.activate()
-  })
+  atom.workspace.open(uri, options)
 }
 
 function createPlantumlViewerUri (editor) {
   return PLANTUML_VIEWER_URI_PROTOCOL + '//editor/' + editor.id
 }
 
+var currentEditor
 function plantumlViewerOpener (uri) {
   try {
     var parsedUri = url.parse(uri)
   } catch (err) { return }
 
   if (parsedUri.protocol !== PLANTUML_VIEWER_URI_PROTOCOL) return
-
   var editorId = parsedUri.pathname.substring(1)
-  return createPlantumlViewerEditor(uri, editorId)
+  if (currentEditor) currentEditor.destroy()
+  currentEditor = createPlantumlViewerEditor(uri, editorId)
+  return currentEditor
 }
 
 function isMarkdownViewerView (object) {


### PR DESCRIPTION
```json
"useNailgun": {
  "type": "boolean",
  "default": false
},
```
Nailgun isn't working properly with the newest version of node-plantuml. Something that needs to be re-initialized isn't getting re-initialized, so we should disable nailgun currently. This only really affects opening new panels, not the live-update, so it's not too terrible.

```javascript
new Buffer(1)
```
TextBuffer seems to require an argument, so we'll pass any number here to be ok. Really though this means the state isn't what we expect, so we could just return null and then stop updating at that point.

```javascript
// function attached () {
disposables.add(atom.workspace.onDidChangeActivePaneItem(function () {
```
This subscription needs to be added to the CompositeDisposable or else you are actually adding new handles every time you open a new panel. This is probably what lead to the problem with the Buffer above or the null-pointer check below

```javascript
if (atom.config.get('plantuml-viewer.liveUpdate') && editor.getBuffer()) {
```
Just checking if the buffer actually exists. Depending on when this is called, it seems the editor or its buffer has already been destroyed.

```javascript
var options = { searchAllPanes: true, activatePane: false }
```
Just an update to the options for a UriOpener. The spec still doesn't pass, though. (It doesn't pass without this either)

```javascript
if (currentEditor) currentEditor.destroy()
currentEditor = createPlantumlViewerEditor(uri, editorId)
return currentEditor
```
It doesn't seem like your previous editors and their subscriptions were properly being disposed. This might not be necessary though.